### PR TITLE
Enhance code quality and align documentation

### DIFF
--- a/dlock-core/src/main/java/com/dlock/core/util/time/DateTimeProvider.java
+++ b/dlock-core/src/main/java/com/dlock/core/util/time/DateTimeProvider.java
@@ -7,20 +7,18 @@ import java.time.LocalDateTime;
  *
  * @author Przemyslaw Malirz
  */
+@FunctionalInterface
 public interface DateTimeProvider {
 
     /**
      * Default singleton implementation.
      */
-    DateTimeProvider SYSTEM = new DateTimeProvider() {
-    };
+    DateTimeProvider SYSTEM = LocalDateTime::now;
 
     /**
      * Returns LocalDateTime.now(). It's not static so can be mocked / replaced by
      * any NOW provider.
      * The hardest part with NOW in unit tests is it's always different ;)
      */
-    default LocalDateTime now() {
-        return LocalDateTime.now();
-    }
+    LocalDateTime now();
 }

--- a/dlock-jdbc/README.md
+++ b/dlock-jdbc/README.md
@@ -48,6 +48,7 @@ Unless you are building a custom integration, you will typically use this via th
 KeyLock keyLock = new JDBCKeyLockBuilder()
     .dataSource(myDataSource)
     .databaseType(DatabaseType.H2)
+    .createDatabase(true) // Automatically creates the DLCK table if not exists
     .build();
 ```
 

--- a/dlock-jdbc/src/main/java/com/dlock/jdbc/tool/schema/InitDatabase.java
+++ b/dlock-jdbc/src/main/java/com/dlock/jdbc/tool/schema/InitDatabase.java
@@ -10,11 +10,12 @@ import java.util.List;
 
 /**
  * Database initiator creates required structures in the database.
- * It can be used concurrently so we have to make sure it works properly when
- * used a few times.
- * Anyway, mostly used for testing as production (and pre-production) regions
- * should not rely on
- * automatic DDL run at start.
+ * The execution is safe even if multiple instances try to initialize the database
+ * concurrently, as the DDL scripts use "IF NOT EXISTS" (or equivalent) clauses.
+ * <p>
+ * This class is primarily intended for testing and development environments.
+ * Production environments should ideally manage database schemas via migration tools
+ * (e.g., Flyway, Liquibase) rather than relying on application startup DDLs.
  *
  * @author Przemyslaw Malirz
  */

--- a/dlock-spring/README.md
+++ b/dlock-spring/README.md
@@ -25,6 +25,7 @@ public class DLockConfig {
         return new JDBCKeyLockBuilder()
                 .dataSource(dataSource)
                 .databaseType(DatabaseType.H2) // or POSTGRESQL, ORACLE
+                .createDatabase(true) // Automatically creates the DLCK table
                 .build();
     }
 }

--- a/dlock-spring/src/main/java/com/dlock/spring/annotation/aspect/LockAspect.java
+++ b/dlock-spring/src/main/java/com/dlock/spring/annotation/aspect/LockAspect.java
@@ -31,6 +31,18 @@ public class LockAspect {
         this.keyLock = keyLock;
     }
 
+    /**
+     * Intercepts method execution to acquire a lock before proceeding.
+     * <p>
+     * If the lock is acquired, the method body is executed, and the lock is released afterward (in a finally block).
+     * If the lock cannot be acquired (e.g., already held by another process), the method execution is skipped,
+     * and {@code null} is returned.
+     *
+     * @param joinPoint the join point representing the method execution
+     * @return the result of the method execution if the lock is acquired, or {@code null} if the lock is not acquired
+     * @throws Throwable if the method execution throws an exception
+     * @throws IllegalStateException if the {@code @Lock} annotation is missing (should not happen due to pointcut)
+     */
     @Around("@annotation(com.dlock.spring.annotation.Lock)")
     public Object aroundLockedMethod(ProceedingJoinPoint joinPoint) throws Throwable {
 


### PR DESCRIPTION
This PR enhances code quality by modernizing `DateTimeProvider` and improving Javadocs. It also aligns the `dlock-jdbc` and `dlock-spring` READMEs with the existing code by adding the `.createDatabase(true)` option to usage examples, ensuring users have a smoother setup experience. All existing tests passed.

---
*PR created automatically by Jules for task [1538409533120051106](https://jules.google.com/task/1538409533120051106) started by @pmalirz*