### PR TITLE
Fix LocalLockRepository concurrency and align documentation

### DIFF
--- a/dlock-api/README.md
+++ b/dlock-api/README.md
@@ -20,14 +20,18 @@ public interface KeyLock {
      * Tries to acquire a lock and, if successful, executes the given action.
      * The lock is automatically released after the action completes.
      */
-    void tryLock(String lockKey, long expirationSeconds, Consumer<LockHandle> action);
+    default void tryLock(String lockKey, long expirationSeconds, Consumer<LockHandle> action) {
+        // ...
+    }
 
     /**
      * Tries to acquire a lock and, if successful, executes the given function.
      * The lock is automatically released after the function completes.
      * @return Optional<R> - Result of the function if lock acquired, empty if not.
      */
-    <R> Optional<R> tryLock(String lockKey, long expirationSeconds, Function<LockHandle, R> action);
+    default <R> Optional<R> tryLock(String lockKey, long expirationSeconds, Function<LockHandle, R> action) {
+        // ...
+    }
 
     /**
      * Releases the lock using the provided handle.

--- a/dlock-core/README.md
+++ b/dlock-core/README.md
@@ -8,6 +8,7 @@ This module contains the core implementation logic for **dlock**, independent of
 * **LockRepository**: Interface for storage backends (e.g., `JDBCLockRepository` implements this).
 * **LockExpirationPolicy**: Strategy for handling lock expiration. Defaults to `LocalLockExpirationPolicy`.
 * **LockHandleIdGenerator**: Strategy for generating unique lock handles. Defaults to UUID.
+* **DateTimeProvider**: Interface for providing current time (for testing and consistency). Defaults to system time.
 
 ## Architecture
 
@@ -28,15 +29,27 @@ To implement a custom storage backend:
 ```java
 public class MyCustomRepository implements LockRepository {
     @Override
-    public boolean tryLock(LockModel lock) {
-        // Implement lock acquisition
+    public boolean createLock(WriteLockRecord lockRecord) {
+        // Implement lock acquisition (e.g. INSERT)
+        // Return true if successful, false if key already exists
         return false;
     }
 
     @Override
-    public boolean unlock(LockModel lock) {
-        // Implement release
-        return false;
+    public ReadLockRecord findLockByHandleId(String lockHandleId) {
+        // Find lock by handle ID
+        return null;
+    }
+
+    @Override
+    public ReadLockRecord findLockByKey(String lockKey) {
+        // Find lock by key
+        return null;
+    }
+
+    @Override
+    public void removeLock(String lockHandleId) {
+        // Remove lock by handle ID
     }
 }
 

--- a/dlock-core/src/main/java/com/dlock/core/repository/LocalLockRepository.java
+++ b/dlock-core/src/main/java/com/dlock/core/repository/LocalLockRepository.java
@@ -4,20 +4,19 @@ import com.dlock.core.model.ReadLockRecord;
 import com.dlock.core.model.WriteLockRecord;
 import com.dlock.core.util.time.DateTimeProvider;
 
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Predicate;
+import java.util.concurrent.ConcurrentMap;
 
 /**
- * This is an in-memory repository implementation backed by the concurrent Set
+ * This is an in-memory repository implementation backed by the concurrent Map
  * implementation
- * ({@link ConcurrentHashMap#newKeySet}).
+ * ({@link ConcurrentHashMap}).
  *
  * @author Przemyslaw Malirz
  */
 public class LocalLockRepository implements LockRepository {
 
-    private final Set<WriteLockRecord> NAMED_LOCK = ConcurrentHashMap.newKeySet();
+    private final ConcurrentMap<String, WriteLockRecord> NAMED_LOCK = new ConcurrentHashMap<>();
     private final DateTimeProvider dateTimeProvider;
 
     public LocalLockRepository(DateTimeProvider dateTimeProvider) {
@@ -26,30 +25,34 @@ public class LocalLockRepository implements LockRepository {
 
     @Override
     public boolean createLock(WriteLockRecord lockRecord) {
-        return NAMED_LOCK.add(lockRecord);
+        return NAMED_LOCK.putIfAbsent(lockRecord.lockKey(), lockRecord) == null;
     }
 
     @Override
     public ReadLockRecord findLockByHandleId(String lockHandleId) {
-        return findBy(lock -> lock.lockHandleId().equals(lockHandleId));
+        return NAMED_LOCK.values().stream()
+                .filter(lock -> lock.lockHandleId().equals(lockHandleId))
+                .findFirst()
+                .map(this::toReadLockRecord)
+                .orElse(null);
     }
 
     @Override
     public ReadLockRecord findLockByKey(String lockKey) {
-        return findBy(lock -> lock.lockKey().equals(lockKey));
+        WriteLockRecord lockRecord = NAMED_LOCK.get(lockKey);
+        if (lockRecord != null) {
+            return toReadLockRecord(lockRecord);
+        }
+        return null;
     }
 
     @Override
     public void removeLock(String lockHandleId) {
-        NAMED_LOCK.removeIf(lock -> lock.lockHandleId().equals(lockHandleId));
+        NAMED_LOCK.values().removeIf(lock -> lock.lockHandleId().equals(lockHandleId));
     }
 
-    private ReadLockRecord findBy(Predicate<WriteLockRecord> predicate) {
-        return NAMED_LOCK.stream()
-                .filter(predicate)
-                .findFirst()
-                .map(it -> ReadLockRecord.of(it, dateTimeProvider.now()))
-                .orElse(null);
+    private ReadLockRecord toReadLockRecord(WriteLockRecord writeLockRecord) {
+        return ReadLockRecord.of(writeLockRecord, dateTimeProvider.now());
     }
 
 }

--- a/dlock-core/src/test/java/com/dlock/core/LocalKeyLockTest.java
+++ b/dlock-core/src/test/java/com/dlock/core/LocalKeyLockTest.java
@@ -10,8 +10,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -79,6 +87,44 @@ class LocalKeyLockTest {
 
         Optional<LockHandle> lock3 = localKeyLock.tryLock("b", 1000);
         assertTrue(lock3.isPresent());
+    }
+
+    @Test
+    void testConcurrentLocking() throws InterruptedException {
+        int threads = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threads);
+        SimpleKeyLock keyLock = new SimpleKeyLock(
+                new LocalLockRepository(DateTimeProvider.SYSTEM),
+                new LockHandleUUIDIdGenerator(),
+                new LocalLockExpirationPolicy(),
+                DateTimeProvider.SYSTEM);
+
+        List<String> acquiredLocks = Collections.synchronizedList(new ArrayList<>());
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threads);
+
+        for (int i = 0; i < threads; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    Optional<LockHandle> handle = keyLock.tryLock("concurrent-key", 10);
+                    if (handle.isPresent()) {
+                        acquiredLocks.add(handle.get().handleId());
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        doneLatch.await(5, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        // Only one thread should acquire the lock
+        assertEquals(1, acquiredLocks.size(), "More than one thread acquired the lock! Acquired: " + acquiredLocks);
     }
 
 }


### PR DESCRIPTION
This PR fixes a critical concurrency bug in `LocalLockRepository` where multiple threads could acquire the same lock key simultaneously. It replaces the internal `Set` storage with a `ConcurrentHashMap` and uses `putIfAbsent` for atomic lock creation.

Additionally, it updates the README documentation for `dlock-core` and `dlock-api` to align with the current codebase, correcting implementation examples and interface signatures.

A regression test for concurrent locking has been added to `LocalKeyLockTest`.

---
*PR created automatically by Jules for task [5086705332043745279](https://jules.google.com/task/5086705332043745279) started by @pmalirz*