### PR TITLE
Refactor SimpleKeyLock and LockAspect for better performance and API

### DIFF
--- a/dlock-core/README.md
+++ b/dlock-core/README.md
@@ -5,6 +5,7 @@ This module contains the core implementation logic for **dlock**, independent of
 ## Components
 
 * **SimpleKeyLock**: The main implementation of `KeyLock` interface. It orchestrates the locking process using a `LockRepository`.
+* **SimpleLocalKeyLock**: A convenient subclass of `SimpleKeyLock` pre-configured with `LocalLockRepository` (in-memory) and default settings. Useful for testing or single-instance applications.
 * **LockRepository**: Interface for storage backends (e.g., `JDBCLockRepository` implements this).
 * **LockExpirationPolicy**: Strategy for handling lock expiration. Defaults to `LocalLockExpirationPolicy`.
 * **LockHandleIdGenerator**: Strategy for generating unique lock handles. Defaults to UUID.

--- a/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
+++ b/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
@@ -36,12 +36,17 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public Optional<LockHandle> tryLock(String lockKey, long expirationSeconds) {
+        // Optimistic approach: try to create a new lock first
+        Optional<LockHandle> newLock = createNewLock(lockKey, expirationSeconds);
+        if (newLock.isPresent()) {
+            return newLock;
+        }
+
+        // If failed, check if the existing lock is expired
         ReadLockRecord currentLockRecord = lockRepository.findLockByKey(lockKey);
 
-        if (expiredOrNotExists(currentLockRecord)) {
-            if (currentLockRecord != null) {
-                breakLock(currentLockRecord);
-            }
+        if (currentLockRecord != null && expired(currentLockRecord)) {
+            breakLock(currentLockRecord);
             return createNewLock(lockKey, expirationSeconds);
         } else {
             return Optional.empty();
@@ -50,10 +55,7 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public void unlock(LockHandle lockHandle) {
-        ReadLockRecord lock = lockRepository.findLockByHandleId(lockHandle.handleId());
-        if (lock != null) {
-            breakLock(lock);
-        }
+        lockRepository.removeLock(lockHandle.handleId());
     }
 
     private Optional<LockHandle> createNewLock(String lockKey, long expirationSeconds) {
@@ -69,10 +71,6 @@ public class SimpleKeyLock implements KeyLock {
     private WriteLockRecord createLockRecord(String lockKey, long expirationSeconds) {
         String lockHandleId = lockHandleIdGenerator.generate();
         return new WriteLockRecord(lockKey, lockHandleId, dateTimeProvider.now(), expirationSeconds);
-    }
-
-    private boolean expiredOrNotExists(ReadLockRecord currentLock) {
-        return currentLock == null || expired(currentLock);
     }
 
     private boolean expired(ReadLockRecord readLockRecord) {

--- a/dlock-jdbc/src/main/java/io/github/pmalirz/dlock/jdbc/repository/JDBCLockRepository.java
+++ b/dlock-jdbc/src/main/java/io/github/pmalirz/dlock/jdbc/repository/JDBCLockRepository.java
@@ -99,9 +99,9 @@ public class JDBCLockRepository implements LockRepository {
                 return null;
             }
 
-            String lockKey = resultSet.getString(1);
-            Timestamp lockCreatedTime = resultSet.getTimestamp(3);
-            long lockExpirationSeconds = resultSet.getLong(4);
+            String lockKey = resultSet.getString("LCK_KEY");
+            Timestamp lockCreatedTime = resultSet.getTimestamp("CREATED_TIME");
+            long lockExpirationSeconds = resultSet.getLong("EXPIRE_SEC");
             Timestamp currentTime = resultSet.getTimestamp(5);
             return new ReadLockRecord(lockKey, lockHandleId, lockCreatedTime.toLocalDateTime(), lockExpirationSeconds,
                     currentTime.toLocalDateTime());
@@ -120,9 +120,9 @@ public class JDBCLockRepository implements LockRepository {
                 return null;
             }
 
-            String lockHandleId = resultSet.getString(2);
-            Timestamp lockCreatedTime = resultSet.getTimestamp(3);
-            long lockExpirationSeconds = resultSet.getLong(4);
+            String lockHandleId = resultSet.getString("LCK_HNDL_ID");
+            Timestamp lockCreatedTime = resultSet.getTimestamp("CREATED_TIME");
+            long lockExpirationSeconds = resultSet.getLong("EXPIRE_SEC");
             Timestamp currentTime = resultSet.getTimestamp(5);
             return new ReadLockRecord(lockKey, lockHandleId, lockCreatedTime.toLocalDateTime(), lockExpirationSeconds,
                     currentTime.toLocalDateTime());
@@ -145,7 +145,7 @@ public class JDBCLockRepository implements LockRepository {
         }
     }
 
-    private int countOccurrences(String str, char ch) {
+    private static int countOccurrences(String str, char ch) {
         return (int) str.chars().filter(c -> c == ch).count();
     }
 

--- a/dlock-spring/README.md
+++ b/dlock-spring/README.md
@@ -55,6 +55,8 @@ public void updateUser(@LockKeyParam("userId") String userId, UserData data) {
 
 ## Important Notes
 
-1. **Return Values**: If the lock is acquired, the method executes and returns its value. If the lock is **not** acquired, the execution is skipped and `null` is returned. Callers should be prepared to handle `null`.
+1. **Return Values**: If the lock is acquired, the method executes and returns its value. If the lock is **not** acquired, the execution is skipped.
+   - If the method returns `Optional<T>`, `Optional.empty()` is returned.
+   - Otherwise, `null` is returned. Callers should be prepared to handle `null`.
 2. **Skipping**: If the lock is not acquired, the method body is **not executed**.
 3. **Self-Invocation**: Due to Spring AOP proxy mechanism, calling an `@Lock` method from within the same class will bypass the aspect (and the lock).

--- a/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspect.java
+++ b/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspect.java
@@ -75,6 +75,9 @@ public class LockAspect {
                 keyLock.unlock(lock.get());
             }
         } else {
+            if (targetMethod.getReturnType() == Optional.class) {
+                return Optional.empty();
+            }
             return null;
         }
     }

--- a/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/utils/LockAspectsUtil.java
+++ b/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/utils/LockAspectsUtil.java
@@ -32,7 +32,7 @@ public class LockAspectsUtil {
 
         if (method.getDeclaringClass().isInterface()) {
             try {
-                return joinPoint.getTarget().getClass().getDeclaredMethod(joinPoint.getSignature().getName(),
+                return joinPoint.getTarget().getClass().getMethod(joinPoint.getSignature().getName(),
                         method.getParameterTypes());
             } catch (NoSuchMethodException e) {
                 return method;

--- a/dlock-spring/src/test/groovy/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspectTest.groovy
+++ b/dlock-spring/src/test/groovy/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspectTest.groovy
@@ -55,6 +55,24 @@ class LockAspectTest extends Specification {
         result == null
     }
 
+    def "should return Optional.empty when lock not acquired for Optional return type"() {
+        given:
+        keyLock.tryLock("test-key", 10) >> Optional.empty()
+
+        def method = TestBean.class.getMethod("lockedMethodWithOptional")
+        signature.getMethod() >> method
+        joinPoint.getSignature() >> signature
+        joinPoint.getTarget() >> new TestBean()
+        joinPoint.getArgs() >> []
+
+        when:
+        def result = lockAspect.aroundLockedMethod(joinPoint)
+
+        then:
+        0 * joinPoint.proceed()
+        result == Optional.empty()
+    }
+
     def "should handle null LockKeyParam"() {
         given:
         def lockHandle = new LockHandle("handle1")
@@ -79,6 +97,11 @@ class LockAspectTest extends Specification {
         @Lock(key = "test-key", expirationSeconds = 10)
         String lockedMethod() {
             return "result"
+        }
+
+        @Lock(key = "test-key", expirationSeconds = 10)
+        Optional<String> lockedMethodWithOptional() {
+            return Optional.of("result")
         }
 
         @Lock(key = "test-key-{param}", expirationSeconds = 10)


### PR DESCRIPTION
This PR improves the dlock codebase by refactoring `SimpleKeyLock` to use an optimistic locking strategy, reducing database round-trips. It also enhances `LockAspect` to gracefully handle `Optional` return types, returning `Optional.empty()` instead of `null` when a lock is not acquired. Additionally, `JDBCLockRepository` is updated to use column labels for safer `ResultSet` access, and documentation is aligned with the code changes.

---
*PR created automatically by Jules for task [12838803548921958082](https://jules.google.com/task/12838803548921958082) started by @pmalirz*