### PR TITLE
fix: throw LockException for primitive return types in @Lock aspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ Annotate your methods with `@Lock`.
 
 **Important**:
 
-* If the lock cannot be acquired (e.g., held by another node), the method execution is **skipped**, and `null` is returned.
+* If the lock cannot be acquired (e.g., held by another node), the method execution is **skipped**.
+* For non-primitive return types, `null` (or `Optional.empty()`) is returned. For primitive return types, a `LockException` is thrown.
 * This pattern is best suited for scheduled tasks or void methods where "skip if running" is the desired behavior.
-* If the method returns a value, the caller must handle `null` in case of lock failure.
+* If the method returns a value, the caller must handle `null` or exceptions in case of lock failure.
 
 ```java
 @Service

--- a/dlock-spring/README.md
+++ b/dlock-spring/README.md
@@ -57,6 +57,7 @@ public void updateUser(@LockKeyParam("userId") String userId, UserData data) {
 
 1. **Return Values**: If the lock is acquired, the method executes and returns its value. If the lock is **not** acquired, the execution is skipped.
    - If the method returns `Optional<T>`, `Optional.empty()` is returned.
+   - If the method returns a primitive type (except `void`), a `LockException` is thrown because `null` cannot be returned.
    - Otherwise, `null` is returned. Callers should be prepared to handle `null`.
 2. **Skipping**: If the lock is not acquired, the method body is **not executed**.
 3. **Self-Invocation**: Due to Spring AOP proxy mechanism, calling an `@Lock` method from within the same class will bypass the aspect (and the lock).

--- a/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspect.java
+++ b/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspect.java
@@ -74,6 +74,9 @@ public class LockAspect {
             if (targetMethod.getReturnType() == Optional.class) {
                 return Optional.empty();
             }
+            if (targetMethod.getReturnType().isPrimitive() && targetMethod.getReturnType() != void.class) {
+                throw new io.github.pmalirz.dlock.api.exception.LockException("Lock could not be acquired for method with primitive return type");
+            }
             return null;
         }
     }

--- a/dlock-spring/src/test/groovy/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspectTest.groovy
+++ b/dlock-spring/src/test/groovy/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspectTest.groovy
@@ -93,6 +93,40 @@ class LockAspectTest extends Specification {
         result == "result"
     }
 
+    def "should throw LockException when lock not acquired for primitive return type"() {
+        given:
+        keyLock.tryLock("test-key", 10) >> Optional.empty()
+
+        def method = TestBean.class.getMethod("lockedMethodWithPrimitive")
+        signature.getMethod() >> method
+        joinPoint.getSignature() >> signature
+        joinPoint.getTarget() >> new TestBean()
+        joinPoint.getArgs() >> []
+
+        when:
+        lockAspect.aroundLockedMethod(joinPoint)
+
+        then:
+        thrown(io.github.pmalirz.dlock.api.exception.LockException)
+    }
+
+    def "should return null when lock not acquired for void return type"() {
+        given:
+        keyLock.tryLock("test-key", 10) >> Optional.empty()
+
+        def method = TestBean.class.getMethod("lockedMethodWithVoid")
+        signature.getMethod() >> method
+        joinPoint.getSignature() >> signature
+        joinPoint.getTarget() >> new TestBean()
+        joinPoint.getArgs() >> []
+
+        when:
+        def result = lockAspect.aroundLockedMethod(joinPoint)
+
+        then:
+        result == null
+    }
+
     static class TestBean {
         @Lock(key = "test-key", expirationSeconds = 10)
         String lockedMethod() {
@@ -107,6 +141,15 @@ class LockAspectTest extends Specification {
         @Lock(key = "test-key-{param}", expirationSeconds = 10)
         String lockedMethodWithParam(@LockKeyParam("param") String param) {
             return "result"
+        }
+
+        @Lock(key = "test-key", expirationSeconds = 10)
+        int lockedMethodWithPrimitive() {
+            return 1
+        }
+
+        @Lock(key = "test-key", expirationSeconds = 10)
+        void lockedMethodWithVoid() {
         }
     }
 }


### PR DESCRIPTION
Fixes an issue in `dlock-spring` where applying `@Lock` to a method returning a primitive type would result in an unboxing error when the lock is not acquired.

Changes:
1. Updated `LockAspect` to throw `LockException` for primitive return types (excluding `void`).
2. Added tests in `LockAspectTest.groovy` to verify this behavior.
3. Updated `README.md` and `dlock-spring/README.md` to document this behavior.

---
*PR created automatically by Jules for task [9797092333193349646](https://jules.google.com/task/9797092333193349646) started by @pmalirz*