### PR TITLE
Enforce API validations and improve Spring parameter discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ sequenceDiagram
 
 When using the `KeyLock` API, keep the following constraints in mind:
 
-* **`lockKey`** must be a non-blank string, up to 1000 characters (the database column limit).
-* **`expirationSeconds`** must be greater than 0.
+* **`lockKey`** must be a non-blank string, up to 1000 characters (the database column limit). If these constraints are violated, an `IllegalArgumentException` is thrown.
+* **`expirationSeconds`** must be greater than 0. If violated, an `IllegalArgumentException` is thrown.
 * **Lock keys should be descriptive and scoped** (e.g., `"/invoice/{id}"`) to avoid unintended collisions.
 
 ## Project Structure

--- a/dlock-core/README.md
+++ b/dlock-core/README.md
@@ -4,7 +4,7 @@ This module contains the core implementation logic for **dlock**, independent of
 
 ## Components
 
-* **SimpleKeyLock**: The main implementation of `KeyLock` interface. It orchestrates the locking process using a `LockRepository`.
+* **SimpleKeyLock**: The main implementation of `KeyLock` interface. It orchestrates the locking process using a `LockRepository`. It enforces the core API constraints (e.g. `lockKey` must be a non-blank string of max length 1000 characters, and `expirationSeconds` must be greater than 0), throwing `IllegalArgumentException` if violated.
 * **SimpleLocalKeyLock**: A convenient subclass of `SimpleKeyLock` pre-configured with `LocalLockRepository` (in-memory) and default settings. Useful for testing or single-instance applications.
 * **LockRepository**: Interface for storage backends (e.g., `JDBCLockRepository` implements this).
 * **LockExpirationPolicy**: Strategy for handling lock expiration. Defaults to `LocalLockExpirationPolicy`.

--- a/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
+++ b/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
@@ -36,6 +36,16 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public Optional<LockHandle> tryLock(String lockKey, long expirationSeconds) {
+        if (lockKey == null || lockKey.isBlank()) {
+            throw new IllegalArgumentException("lockKey must not be null or blank");
+        }
+        if (lockKey.length() > 1000) {
+            throw new IllegalArgumentException("lockKey must not be longer than 1000 characters");
+        }
+        if (expirationSeconds <= 0) {
+            throw new IllegalArgumentException("expirationSeconds must be greater than 0");
+        }
+
         // Optimistic approach: try to create a new lock first
         Optional<LockHandle> newLock = createNewLock(lockKey, expirationSeconds);
         if (newLock.isPresent()) {

--- a/dlock-spring/README.md
+++ b/dlock-spring/README.md
@@ -44,7 +44,7 @@ public void generateDailyReport() {
 
 ### Dynamic Keys
 
-Use `@LockKeyParam` to include method arguments in the lock key.
+Use `@LockKeyParam` to include method arguments in the lock key. If `@LockKeyParam` is not provided and you compile with `-parameters` flag, the parameter name will be used directly as the placeholder.
 
 ```java
 @Lock(key = "user-update-{userId}", expirationSeconds = 60)

--- a/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspect.java
+++ b/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/LockAspect.java
@@ -63,6 +63,12 @@ public class LockAspect {
 
         lockKeyValue = replaceKeyParameters(lockKeyValue, joinPoint, parameters);
 
+        // Fallback for reflection-based parameter names (if compiled with -parameters and not using @LockKeyParam)
+        if (parameters.isEmpty()) {
+            parameters = LockAspectsUtil.getReflectionMethodParameters(targetMethod);
+            lockKeyValue = replaceKeyParameters(lockKeyValue, joinPoint, parameters);
+        }
+
         Optional<LockHandle> lock = keyLock.tryLock(lockKeyValue, lockAnnotation.expirationSeconds());
         if (lock.isPresent()) {
             try {

--- a/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/utils/LockAspectsUtil.java
+++ b/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/aspect/utils/LockAspectsUtil.java
@@ -64,4 +64,23 @@ public class LockAspectsUtil {
         return result;
     }
 
+    /**
+     * Returns all the method parameters using parameter names derived via reflection.
+     * Useful as a fallback when @LockKeyParam is not present, assuming the code is compiled with -parameters.
+     *
+     * @return List of parameters info
+     */
+    public static List<LockKeyParameter> getReflectionMethodParameters(Method method) {
+        List<LockKeyParameter> result = new ArrayList<>();
+        Parameter[] parameters = method.getParameters();
+        for (int i = 0; i < parameters.length; i++) {
+            Parameter parameter = parameters[i];
+            // Only add if parameter name is actually available (e.g., compiled with -parameters)
+            if (parameter.isNamePresent()) {
+                result.add(new LockKeyParameter(i, parameter.getName()));
+            }
+        }
+        return result;
+    }
+
 }

--- a/dlock-spring/src/test/java/io/github/pmalirz/dlock/spring/annotation/aspect/utils/LockAspectsUtilReflectionTest.java
+++ b/dlock-spring/src/test/java/io/github/pmalirz/dlock/spring/annotation/aspect/utils/LockAspectsUtilReflectionTest.java
@@ -1,0 +1,31 @@
+package io.github.pmalirz.dlock.spring.annotation.aspect.utils;
+
+import org.junit.jupiter.api.Test;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LockAspectsUtilReflectionTest {
+
+    @Test
+    void testReflectionParams() throws Exception {
+        Method method = LockAspectsUtilReflectionTest.class.getDeclaredMethod("myMethod", String.class, int.class);
+
+        List<LockAspectsUtil.LockKeyParameter> params = LockAspectsUtil.getReflectionMethodParameters(method);
+
+        // This test only verifies something if the project is compiled with -parameters.
+        // If not, it will just return empty, which is also expected behavior when the flag isn't present.
+        if (!params.isEmpty()) {
+            assertEquals(2, params.size());
+            assertEquals("paramOne", params.get(0).name());
+            assertEquals("paramTwo", params.get(1).name());
+        } else {
+            assertTrue(params.isEmpty());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    void myMethod(String paramOne, int paramTwo) {}
+}


### PR DESCRIPTION
Addresses issues where the stated API guidelines and constraints were not enforced by the code. 

- `SimpleKeyLock` now throws `IllegalArgumentException` for invalid `lockKey` and `expirationSeconds`.
- Spring annotation integration now falls back to parameter names extracted via reflection if `@LockKeyParam` is not provided (assuming `-parameters` compiler flag is used).
- Documentation correctly aligned with these enhancements.

---
*PR created automatically by Jules for task [6701795757973668722](https://jules.google.com/task/6701795757973668722) started by @pmalirz*