### PR TITLE
Enforce key and expiration constraints in tryLock

### DIFF
--- a/dlock-api/README.md
+++ b/dlock-api/README.md
@@ -13,6 +13,8 @@ public interface KeyLock {
     /**
      * Attempts to acquire a lock by key.
      * @return Optional<LockHandle> - Present if acquired, empty if not.
+     * @throws IllegalArgumentException if lockKey is null/blank or > 1000 characters,
+     *                                  or if expirationSeconds is <= 0.
      */
     Optional<LockHandle> tryLock(String lockKey, long expirationSeconds);
 

--- a/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
+++ b/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
@@ -19,6 +19,8 @@ public interface KeyLock {
      * If the lock is taken by someone there is no exception thrown but simply
      * {@link Optional#empty} is returned.
      *
+     * @throws IllegalArgumentException if lockKey is null/blank or > 1000 characters,
+     *                                  or if expirationSeconds is <= 0.
      * @throws io.github.pmalirz.dlock.api.exception.LockException if an unexpected error occurs
      *                                               during lock acquisition
      */
@@ -32,6 +34,8 @@ public interface KeyLock {
      * @param lockKey           the key identifying the lock
      * @param expirationSeconds the lock expiration time in seconds
      * @param action            the action to execute while holding the lock
+     * @throws IllegalArgumentException if lockKey is null/blank or > 1000 characters,
+     *                                  or if expirationSeconds is <= 0.
      * @throws io.github.pmalirz.dlock.api.exception.LockException if an unexpected error occurs
      *                                               during lock acquisition
      */
@@ -59,6 +63,8 @@ public interface KeyLock {
      * @param <R>               the return type of the action
      * @return an {@link Optional} containing the result of the action if the lock
      *         was acquired, or empty otherwise
+     * @throws IllegalArgumentException if lockKey is null/blank or > 1000 characters,
+     *                                  or if expirationSeconds is <= 0.
      * @throws io.github.pmalirz.dlock.api.exception.LockException if an unexpected error occurs
      *                                               during lock acquisition
      */

--- a/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
+++ b/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
@@ -36,6 +36,16 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public Optional<LockHandle> tryLock(String lockKey, long expirationSeconds) {
+        if (lockKey == null || lockKey.trim().isEmpty()) {
+            throw new IllegalArgumentException("lockKey must be a non-blank string");
+        }
+        if (lockKey.length() > 1000) {
+            throw new IllegalArgumentException("lockKey must be up to 1000 characters");
+        }
+        if (expirationSeconds <= 0) {
+            throw new IllegalArgumentException("expirationSeconds must be greater than 0");
+        }
+
         // Optimistic approach: try to create a new lock first
         Optional<LockHandle> newLock = createNewLock(lockKey, expirationSeconds);
         if (newLock.isPresent()) {

--- a/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
+++ b/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
@@ -57,6 +57,37 @@ class LocalKeyLockTest {
     }
 
     @Test
+    void tryLockWithInvalidParameters() {
+        // Invalid lockKey
+        Exception e1 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock(null, 1000);
+        });
+        assertEquals("lockKey must be a non-blank string", e1.getMessage());
+
+        Exception e2 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock("   ", 1000);
+        });
+        assertEquals("lockKey must be a non-blank string", e2.getMessage());
+
+        String longKey = "a".repeat(1001);
+        Exception e3 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock(longKey, 1000);
+        });
+        assertEquals("lockKey must be up to 1000 characters", e3.getMessage());
+
+        // Invalid expirationSeconds
+        Exception e4 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock("valid-key", 0);
+        });
+        assertEquals("expirationSeconds must be greater than 0", e4.getMessage());
+
+        Exception e5 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock("valid-key", -1);
+        });
+        assertEquals("expirationSeconds must be greater than 0", e5.getMessage());
+    }
+
+    @Test
     void tryLockAndUnlock() {
         Optional<LockHandle> lock1 = localKeyLock.tryLock("a", 1000);
         Optional<LockHandle> lock2 = localKeyLock.tryLock("a", 1000);

--- a/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/Lock.java
+++ b/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/Lock.java
@@ -15,7 +15,13 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Lock {
+    /**
+     * The lock key. Must be non-blank and up to 1000 characters.
+     */
     String key();
 
+    /**
+     * The lock expiration time in seconds. Must be greater than 0.
+     */
     long expirationSeconds();
 }


### PR DESCRIPTION
This commit enforces the API guidelines mentioned in the main `README.md` by actively validating `lockKey` and `expirationSeconds` inside `SimpleKeyLock.tryLock`. Tests were added in `LocalKeyLockTest` to cover these cases. The `dlock-api` `README.md`, `KeyLock` interface, and `Lock` annotation javadoc were also updated to document these exact constraints clearly for users of the API.

---
*PR created automatically by Jules for task [17866737927708384857](https://jules.google.com/task/17866737927708384857) started by @pmalirz*