### PR TITLE
Enforce API constraints and align READMEs with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Annotate your methods with `@Lock`.
 **Important**:
 
 * If the lock cannot be acquired (e.g., held by another node), the method execution is **skipped**.
-* For non-primitive return types, `null` (or `Optional.empty()`) is returned. For primitive return types, a `LockException` is thrown.
+* If the method returns `Optional<T>`, `Optional.empty()` is returned. For other non-primitive return types, `null` is returned. For primitive return types (except `void`), a `LockException` is thrown.
 * This pattern is best suited for scheduled tasks or void methods where "skip if running" is the desired behavior.
 * If the method returns a value, the caller must handle `null` or exceptions in case of lock failure.
 

--- a/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
+++ b/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
@@ -36,6 +36,16 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public Optional<LockHandle> tryLock(String lockKey, long expirationSeconds) {
+        if (lockKey == null || lockKey.trim().isEmpty()) {
+            throw new IllegalArgumentException("lockKey must be a non-blank string");
+        }
+        if (lockKey.length() > 1000) {
+            throw new IllegalArgumentException("lockKey must be up to 1000 characters");
+        }
+        if (expirationSeconds <= 0) {
+            throw new IllegalArgumentException("expirationSeconds must be greater than 0");
+        }
+
         // Optimistic approach: try to create a new lock first
         Optional<LockHandle> newLock = createNewLock(lockKey, expirationSeconds);
         if (newLock.isPresent()) {

--- a/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
+++ b/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
@@ -57,6 +57,46 @@ class LocalKeyLockTest {
     }
 
     @Test
+    void tryLockWithInvalidParameters() {
+        // null key
+        IllegalArgumentException e1 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock(null, 10);
+        });
+        assertEquals("lockKey must be a non-blank string", e1.getMessage());
+
+        // empty key
+        IllegalArgumentException e2 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock("", 10);
+        });
+        assertEquals("lockKey must be a non-blank string", e2.getMessage());
+
+        // blank key
+        IllegalArgumentException e3 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock("   ", 10);
+        });
+        assertEquals("lockKey must be a non-blank string", e3.getMessage());
+
+        // key > 1000 characters
+        String longKey = "a".repeat(1001);
+        IllegalArgumentException e4 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock(longKey, 10);
+        });
+        assertEquals("lockKey must be up to 1000 characters", e4.getMessage());
+
+        // expiration = 0
+        IllegalArgumentException e5 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock("key", 0);
+        });
+        assertEquals("expirationSeconds must be greater than 0", e5.getMessage());
+
+        // expiration < 0
+        IllegalArgumentException e6 = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            localKeyLock.tryLock("key", -1);
+        });
+        assertEquals("expirationSeconds must be greater than 0", e6.getMessage());
+    }
+
+    @Test
     void tryLockAndUnlock() {
         Optional<LockHandle> lock1 = localKeyLock.tryLock("a", 1000);
         Optional<LockHandle> lock2 = localKeyLock.tryLock("a", 1000);


### PR DESCRIPTION
Fixes the lack of runtime validation matching the API documentation rules, and aligns documentation on Spring Boot integration with the code's real behavior.

---
*PR created automatically by Jules for task [5901506626693296536](https://jules.google.com/task/5901506626693296536) started by @pmalirz*