### PR TITLE
fix: Add tryLock validation and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ You can also use the API directly without Spring.
 KeyLock keyLock = new JDBCKeyLockBuilder()
         .dataSource(dataSource)
         .databaseType(DatabaseType.H2)
+        .createDatabase(true) // Automatically creates the DLCK table
         .build();
 
 // 2. Try to acquire a lock

--- a/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
+++ b/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
@@ -36,6 +36,16 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public Optional<LockHandle> tryLock(String lockKey, long expirationSeconds) {
+        if (lockKey == null || lockKey.isBlank()) {
+            throw new IllegalArgumentException("lockKey must be non-blank");
+        }
+        if (lockKey.length() > 1000) {
+            throw new IllegalArgumentException("lockKey must be at most 1000 characters");
+        }
+        if (expirationSeconds <= 0) {
+            throw new IllegalArgumentException("expirationSeconds must be greater than 0");
+        }
+
         // Optimistic approach: try to create a new lock first
         Optional<LockHandle> newLock = createNewLock(lockKey, expirationSeconds);
         if (newLock.isPresent()) {

--- a/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
+++ b/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -87,6 +88,19 @@ class LocalKeyLockTest {
 
         Optional<LockHandle> lock3 = localKeyLock.tryLock("b", 1000);
         assertTrue(lock3.isPresent());
+    }
+
+    @Test
+    void testInvalidLockKeyAndExpiration() {
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock(null, 10));
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("", 10));
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("   ", 10));
+
+        String longKey = "a".repeat(1001);
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock(longKey, 10));
+
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("valid-key", 0));
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("valid-key", -5));
     }
 
     @Test


### PR DESCRIPTION
This PR improves the code robustness by adding input validation to `SimpleKeyLock.tryLock` and aligns the `README.md` to properly document the `createDatabase(true)` configuration option.

Changes:
1. `SimpleKeyLock.tryLock`: Added `IllegalArgumentException` throws if `lockKey` is blank, over 1000 characters, or `expirationSeconds` is negative.
2. `LocalKeyLockTest`: Added test coverage for invalid lock keys and expiration values.
3. `README.md`: Added `.createDatabase(true)` to `JDBCKeyLockBuilder` usage example to be consistent with sub-module documentation.

---
*PR created automatically by Jules for task [8774782446084218169](https://jules.google.com/task/8774782446084218169) started by @pmalirz*