### PR TITLE
Enforce API guidelines in SimpleKeyLock and align dlock-api README

### DIFF
--- a/dlock-api/README.md
+++ b/dlock-api/README.md
@@ -18,7 +18,8 @@ public interface KeyLock {
 
     /**
      * Tries to acquire a lock and, if successful, executes the given action.
-     * The lock is automatically released after the action completes.
+     * The lock is automatically released after the action completes (or throws).
+     * If the lock is not available, the action is not executed.
      */
     default void tryLock(String lockKey, long expirationSeconds, Consumer<LockHandle> action) {
         // ...
@@ -26,7 +27,9 @@ public interface KeyLock {
 
     /**
      * Tries to acquire a lock and, if successful, executes the given function.
-     * The lock is automatically released after the function completes.
+     * The lock is automatically released after the function completes (or throws).
+     * If the lock is not available, the function is not executed and
+     * Optional.empty() is returned.
      * @return Optional<R> - Result of the function if lock acquired, empty if not.
      */
     default <R> Optional<R> tryLock(String lockKey, long expirationSeconds, Function<LockHandle, R> action) {

--- a/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
+++ b/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
@@ -36,6 +36,16 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public Optional<LockHandle> tryLock(String lockKey, long expirationSeconds) {
+        if (lockKey == null || lockKey.trim().isEmpty()) {
+            throw new IllegalArgumentException("lockKey must be a non-blank string");
+        }
+        if (lockKey.length() > 1000) {
+            throw new IllegalArgumentException("lockKey must be up to 1000 characters");
+        }
+        if (expirationSeconds <= 0) {
+            throw new IllegalArgumentException("expirationSeconds must be greater than 0");
+        }
+
         // Optimistic approach: try to create a new lock first
         Optional<LockHandle> newLock = createNewLock(lockKey, expirationSeconds);
         if (newLock.isPresent()) {
@@ -55,6 +65,9 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public void unlock(LockHandle lockHandle) {
+        if (lockHandle == null || lockHandle.handleId() == null) {
+            return;
+        }
         lockRepository.removeLock(lockHandle.handleId());
     }
 

--- a/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
+++ b/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -87,6 +88,16 @@ class LocalKeyLockTest {
 
         Optional<LockHandle> lock3 = localKeyLock.tryLock("b", 1000);
         assertTrue(lock3.isPresent());
+    }
+
+    @Test
+    void tryLockWithInvalidParameters() {
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock(null, 1000));
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("", 1000));
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("   ", 1000));
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a".repeat(1001), 1000));
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a", 0));
+        assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a", -1));
     }
 
     @Test


### PR DESCRIPTION
Enforces the API guidelines listed in the root `README.md` within `SimpleKeyLock` using fail-fast `IllegalArgumentException` checks. Adds null-safety to `unlock`. Aligns `dlock-api/README.md` with the current code.

---
*PR created automatically by Jules for task [7092715494353643568](https://jules.google.com/task/7092715494353643568) started by @pmalirz*