### PR TITLE
Enforce KeyLock API constraints and synchronize READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,10 @@ sequenceDiagram
 
 When using the `KeyLock` API, keep the following constraints in mind:
 
-* **`lockKey`** must be a non-blank string, up to 1000 characters (the database column limit).
-* **`expirationSeconds`** must be greater than 0.
+* **`lockKey`** must be a non-blank string, up to 1000 characters (the database column limit). `SimpleKeyLock.tryLock` enforces this by throwing an `IllegalArgumentException`.
+* **`expirationSeconds`** must be greater than 0. `SimpleKeyLock.tryLock` enforces this by throwing an `IllegalArgumentException`.
 * **Lock keys should be descriptive and scoped** (e.g., `"/invoice/{id}"`) to avoid unintended collisions.
+* **`unlock`** operations with a `null` `LockHandle` are safely ignored by `SimpleKeyLock.unlock`.
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ sequenceDiagram
 
 When using the `KeyLock` API, keep the following constraints in mind:
 
-* **`lockKey`** must be a non-blank string, up to 1000 characters (the database column limit). `SimpleKeyLock.tryLock` enforces this by throwing an `IllegalArgumentException`.
+* **`lockKey`** must be a non-blank string, up to `KeyLock.MAX_LOCK_KEY_LENGTH` characters (the database column limit). `SimpleKeyLock.tryLock` enforces this by throwing an `IllegalArgumentException`.
 * **`expirationSeconds`** must be greater than 0. `SimpleKeyLock.tryLock` enforces this by throwing an `IllegalArgumentException`.
 * **Lock keys should be descriptive and scoped** (e.g., `"/invoice/{id}"`) to avoid unintended collisions.
 * **`unlock`** operations with a `null` `LockHandle` are safely ignored by `SimpleKeyLock.unlock`.

--- a/dlock-api/README.md
+++ b/dlock-api/README.md
@@ -12,7 +12,11 @@ The primary interface for simplified lock operations.
 public interface KeyLock {
     /**
      * Attempts to acquire a lock by key.
+     *
+     * @param lockKey           the key identifying the lock (must be non-blank and max 1000 characters)
+     * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @return Optional<LockHandle> - Present if acquired, empty if not.
+     * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0
      */
     Optional<LockHandle> tryLock(String lockKey, long expirationSeconds);
 
@@ -35,6 +39,7 @@ public interface KeyLock {
 
     /**
      * Releases the lock using the provided handle.
+     * If the lockHandle is null, it safely returns early.
      */
     void unlock(LockHandle lockHandle);
 }

--- a/dlock-api/README.md
+++ b/dlock-api/README.md
@@ -13,7 +13,7 @@ public interface KeyLock {
     /**
      * Attempts to acquire a lock by key.
      *
-     * @param lockKey           the key identifying the lock (must be non-blank and max 1000 characters)
+     * @param lockKey           the key identifying the lock (must be non-blank and max {@value #MAX_LOCK_KEY_LENGTH} characters)
      * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @return Optional<LockHandle> - Present if acquired, empty if not.
      * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0

--- a/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
+++ b/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
@@ -13,6 +13,8 @@ import java.util.function.Function;
  */
 public interface KeyLock {
 
+    int MAX_LOCK_KEY_LENGTH = 1000;
+
     /**
      * Gets a lock for a given amount of time, if available (providing the handle of
      * that lock).

--- a/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
+++ b/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
@@ -19,8 +19,11 @@ public interface KeyLock {
      * If the lock is taken by someone there is no exception thrown but simply
      * {@link Optional#empty} is returned.
      *
+     * @param lockKey           the key identifying the lock (must be non-blank and max 1000 characters)
+     * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @throws io.github.pmalirz.dlock.api.exception.LockException if an unexpected error occurs
      *                                               during lock acquisition
+     * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0
      */
     Optional<LockHandle> tryLock(String lockKey, long expirationSeconds);
 
@@ -78,7 +81,7 @@ public interface KeyLock {
 
     /**
      * Releases a given lock. If lock with a given handle does not exist nothings
-     * happen.
+     * happen. If the given handle is null, it should safely return.
      */
     void unlock(LockHandle lockHandle);
 

--- a/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
+++ b/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
@@ -25,7 +25,7 @@ public interface KeyLock {
      * If the lock is taken by someone there is no exception thrown but simply
      * {@link Optional#empty} is returned.
      *
-     * @param lockKey           the key identifying the lock (must be non-blank and max 1000 characters)
+     * @param lockKey           the key identifying the lock (must be non-blank and max {@value #MAX_LOCK_KEY_LENGTH} characters)
      * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @throws io.github.pmalirz.dlock.api.exception.LockException if an unexpected error occurs
      *                                               during lock acquisition

--- a/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
+++ b/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
@@ -13,6 +13,10 @@ import java.util.function.Function;
  */
 public interface KeyLock {
 
+    /**
+     * Maximum allowed length for a lock key.
+     * This limit ensures compatibility with the underlying database schema.
+     */
     int MAX_LOCK_KEY_LENGTH = 1000;
 
     /**

--- a/dlock-core/README.md
+++ b/dlock-core/README.md
@@ -4,7 +4,7 @@ This module contains the core implementation logic for **dlock**, independent of
 
 ## Components
 
-* **SimpleKeyLock**: The main implementation of `KeyLock` interface. It orchestrates the locking process using a `LockRepository`. It enforces basic API constraints for `lockKey` (non-blank, max 1000 characters) and `expirationSeconds` (greater than 0) by throwing an `IllegalArgumentException`. The `unlock` method safely handles `null` handles without throwing errors.
+* **SimpleKeyLock**: The main implementation of `KeyLock` interface. It orchestrates the locking process using a `LockRepository`. It enforces basic API constraints for `lockKey` (non-blank, max `KeyLock.MAX_LOCK_KEY_LENGTH` characters) and `expirationSeconds` (greater than 0) by throwing an `IllegalArgumentException`. The `unlock` method safely handles `null` handles without throwing errors.
 * **SimpleLocalKeyLock**: A convenient subclass of `SimpleKeyLock` pre-configured with `LocalLockRepository` (in-memory) and default settings. Useful for testing or single-instance applications.
 * **LockRepository**: Interface for storage backends (e.g., `JDBCLockRepository` implements this).
 * **LockExpirationPolicy**: Strategy for handling lock expiration. Defaults to `LocalLockExpirationPolicy`.

--- a/dlock-core/README.md
+++ b/dlock-core/README.md
@@ -4,7 +4,7 @@ This module contains the core implementation logic for **dlock**, independent of
 
 ## Components
 
-* **SimpleKeyLock**: The main implementation of `KeyLock` interface. It orchestrates the locking process using a `LockRepository`.
+* **SimpleKeyLock**: The main implementation of `KeyLock` interface. It orchestrates the locking process using a `LockRepository`. It enforces basic API constraints for `lockKey` (non-blank, max 1000 characters) and `expirationSeconds` (greater than 0) by throwing an `IllegalArgumentException`. The `unlock` method safely handles `null` handles without throwing errors.
 * **SimpleLocalKeyLock**: A convenient subclass of `SimpleKeyLock` pre-configured with `LocalLockRepository` (in-memory) and default settings. Useful for testing or single-instance applications.
 * **LockRepository**: Interface for storage backends (e.g., `JDBCLockRepository` implements this).
 * **LockExpirationPolicy**: Strategy for handling lock expiration. Defaults to `LocalLockExpirationPolicy`.

--- a/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
+++ b/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
@@ -36,6 +36,13 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public Optional<LockHandle> tryLock(String lockKey, long expirationSeconds) {
+        if (lockKey == null || lockKey.trim().isEmpty() || lockKey.length() > 1000) {
+            throw new IllegalArgumentException("lockKey must be a non-blank string, up to 1000 characters");
+        }
+        if (expirationSeconds <= 0) {
+            throw new IllegalArgumentException("expirationSeconds must be greater than 0");
+        }
+
         // Optimistic approach: try to create a new lock first
         Optional<LockHandle> newLock = createNewLock(lockKey, expirationSeconds);
         if (newLock.isPresent()) {
@@ -55,6 +62,9 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public void unlock(LockHandle lockHandle) {
+        if (lockHandle == null) {
+            return;
+        }
         lockRepository.removeLock(lockHandle.handleId());
     }
 

--- a/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
+++ b/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
@@ -36,8 +36,8 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public Optional<LockHandle> tryLock(String lockKey, long expirationSeconds) {
-        if (lockKey == null || lockKey.trim().isEmpty() || lockKey.length() > 1000) {
-            throw new IllegalArgumentException("lockKey must be a non-blank string, up to 1000 characters");
+        if (lockKey == null || lockKey.trim().isEmpty() || lockKey.length() > MAX_LOCK_KEY_LENGTH) {
+            throw new IllegalArgumentException("lockKey must be a non-blank string, up to " + MAX_LOCK_KEY_LENGTH + " characters");
         }
         if (expirationSeconds <= 0) {
             throw new IllegalArgumentException("expirationSeconds must be greater than 0");

--- a/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
+++ b/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
@@ -61,7 +61,7 @@ class LocalKeyLockTest {
         org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock(null, 1000));
         org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("", 1000));
         org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("   ", 1000));
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a".repeat(1001), 1000));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a".repeat(io.github.pmalirz.dlock.api.KeyLock.MAX_LOCK_KEY_LENGTH + 1), 1000));
 
         org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a", 0));
         org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a", -1));

--- a/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
+++ b/dlock-core/src/test/java/io/github/pmalirz/dlock/core/LocalKeyLockTest.java
@@ -57,6 +57,22 @@ class LocalKeyLockTest {
     }
 
     @Test
+    void shouldThrowExceptionForInvalidLockKeyAndExpiration() {
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock(null, 1000));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("", 1000));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("   ", 1000));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a".repeat(1001), 1000));
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a", 0));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> localKeyLock.tryLock("a", -1));
+    }
+
+    @Test
+    void shouldNotThrowExceptionForNullUnlock() {
+        org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> localKeyLock.unlock(null));
+    }
+
+    @Test
     void tryLockAndUnlock() {
         Optional<LockHandle> lock1 = localKeyLock.tryLock("a", 1000);
         Optional<LockHandle> lock2 = localKeyLock.tryLock("a", 1000);


### PR DESCRIPTION
This submission implements strict input validation for the `tryLock` method inside `SimpleKeyLock` to guarantee safe database operations and enforce documented API constraints. The changes reject empty/null/oversized lock keys and invalid expiration times, while properly handling `null` references during `unlock`. It includes unit test coverage for these edge cases. Additionally, documentation across the main `README.md`, `dlock-core/README.md`, and `dlock-api` interface Javadocs has been fully updated to explicitly outline these constraints, fulfilling the requirement for a clean, secure API and aligned documentation.

---
*PR created automatically by Jules for task [6709944941719295175](https://jules.google.com/task/6709944941719295175) started by @pmalirz*