### PR TITLE
Align Javadocs and READMEs with actual code constraints

### DIFF
--- a/dlock-api/README.md
+++ b/dlock-api/README.md
@@ -23,6 +23,10 @@ public interface KeyLock {
     /**
      * Tries to acquire a lock and, if successful, executes the given action.
      * The lock is automatically released after the action completes.
+     *
+     * @param lockKey           the key identifying the lock (must be non-blank and max {@value #MAX_LOCK_KEY_LENGTH} characters)
+     * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
+     * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0
      */
     default void tryLock(String lockKey, long expirationSeconds, Consumer<LockHandle> action) {
         // ...
@@ -31,7 +35,11 @@ public interface KeyLock {
     /**
      * Tries to acquire a lock and, if successful, executes the given function.
      * The lock is automatically released after the function completes.
+     *
+     * @param lockKey           the key identifying the lock (must be non-blank and max {@value #MAX_LOCK_KEY_LENGTH} characters)
+     * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @return Optional<R> - Result of the function if lock acquired, empty if not.
+     * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0
      */
     default <R> Optional<R> tryLock(String lockKey, long expirationSeconds, Function<LockHandle, R> action) {
         // ...

--- a/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
+++ b/dlock-api/src/main/java/io/github/pmalirz/dlock/api/KeyLock.java
@@ -38,11 +38,12 @@ public interface KeyLock {
      * The lock is automatically released after the action completes (or throws).
      * If the lock is not available, the action is not executed.
      *
-     * @param lockKey           the key identifying the lock
-     * @param expirationSeconds the lock expiration time in seconds
+     * @param lockKey           the key identifying the lock (must be non-blank and max {@value #MAX_LOCK_KEY_LENGTH} characters)
+     * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @param action            the action to execute while holding the lock
      * @throws io.github.pmalirz.dlock.api.exception.LockException if an unexpected error occurs
      *                                               during lock acquisition
+     * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0
      */
     default void tryLock(String lockKey, long expirationSeconds, Consumer<LockHandle> action) {
         Optional<LockHandle> lock = tryLock(lockKey, expirationSeconds);
@@ -62,14 +63,15 @@ public interface KeyLock {
      * If the lock is not available, the function is not executed and
      * {@link Optional#empty()} is returned.
      *
-     * @param lockKey           the key identifying the lock
-     * @param expirationSeconds the lock expiration time in seconds
+     * @param lockKey           the key identifying the lock (must be non-blank and max {@value #MAX_LOCK_KEY_LENGTH} characters)
+     * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @param action            the function to execute while holding the lock
      * @param <R>               the return type of the action
      * @return an {@link Optional} containing the result of the action if the lock
      *         was acquired, or empty otherwise
      * @throws io.github.pmalirz.dlock.api.exception.LockException if an unexpected error occurs
      *                                               during lock acquisition
+     * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0
      */
     default <R> Optional<R> tryLock(String lockKey, long expirationSeconds, Function<LockHandle, R> action) {
         Optional<LockHandle> lock = tryLock(lockKey, expirationSeconds);
@@ -86,8 +88,8 @@ public interface KeyLock {
     }
 
     /**
-     * Releases a given lock. If lock with a given handle does not exist nothings
-     * happen. If the given handle is null, it should safely return.
+     * Releases a given lock. If lock with a given handle does not exist nothing
+     * happens. If the given handle is null, it should safely return.
      */
     void unlock(LockHandle lockHandle);
 

--- a/dlock-jdbc/README.md
+++ b/dlock-jdbc/README.md
@@ -27,7 +27,7 @@ To support other databases, valid SQL scripts must be provided for the `ScriptRe
 | Layer | Mechanism | What It Prevents |
 | :--- | :--- | :--- |
 | 1. **DELETE by handle ID** | Expired locks are removed using their unique `LCK_HNDL_ID` | Cannot accidentally delete another process's newly acquired lock |
-| 2. **Conditional INSERT** | `INSERT...SELECT...WHERE NOT EXISTS (SELECT 1 ... WHERE LCK_KEY = ?)` | Prevents inserting a duplicate lock if another process just acquired it |
+| 2. **Conditional INSERT** | `INSERT...SELECT...WHERE NOT EXISTS` (H2, Oracle) or `ON CONFLICT DO NOTHING` (PostgreSQL) | Prevents inserting a duplicate lock if another process just acquired it |
 | 3. **PRIMARY KEY on `LCK_KEY`** | Database-enforced unique constraint | Ultimate safety net — the database itself rejects any double-insert |
 
 ### Concurrent Expiration Reclaim

--- a/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/Lock.java
+++ b/dlock-spring/src/main/java/io/github/pmalirz/dlock/spring/annotation/Lock.java
@@ -15,7 +15,15 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Lock {
+    /**
+     * The key identifying the lock.
+     * Must be a non-blank string, up to {@value io.github.pmalirz.dlock.api.KeyLock#MAX_LOCK_KEY_LENGTH} characters.
+     * Can contain parameters referencing method arguments via {@link LockKeyParam}.
+     */
     String key();
 
+    /**
+     * The lock expiration time in seconds. Must be greater than 0.
+     */
     long expirationSeconds();
 }


### PR DESCRIPTION
This submission updates the Javadocs and READMEs across the repository to ensure they accurately reflect the current code constraints, specifically the parameters `lockKey` and `expirationSeconds`, and aligns the `dlock-jdbc` README with the `ON CONFLICT DO NOTHING` approach used for PostgreSQL.

---
*PR created automatically by Jules for task [1021213461243690294](https://jules.google.com/task/1021213461243690294) started by @pmalirz*