### PR TITLE
docs: align README examples and clean up string validation in SimpleKeyLock

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ You can also use the API directly without Spring.
 KeyLock keyLock = new JDBCKeyLockBuilder()
         .dataSource(dataSource)
         .databaseType(DatabaseType.H2)
+        .createDatabase(true) // Automatically creates the DLCK table
         .build();
 
 // 2. Try to acquire a lock

--- a/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
+++ b/dlock-core/src/main/java/io/github/pmalirz/dlock/core/SimpleKeyLock.java
@@ -36,7 +36,7 @@ public class SimpleKeyLock implements KeyLock {
 
     @Override
     public Optional<LockHandle> tryLock(String lockKey, long expirationSeconds) {
-        if (lockKey == null || lockKey.trim().isEmpty() || lockKey.length() > MAX_LOCK_KEY_LENGTH) {
+        if (lockKey == null || lockKey.isBlank() || lockKey.length() > MAX_LOCK_KEY_LENGTH) {
             throw new IllegalArgumentException("lockKey must be a non-blank string, up to " + MAX_LOCK_KEY_LENGTH + " characters");
         }
         if (expirationSeconds <= 0) {


### PR DESCRIPTION
This PR addresses the request to improve overall clean code practices while perfectly aligning the README documentation with existing codebase capabilities. 

Changes include:
- Adding the missing `.createDatabase(true)` to the programmatic use case example in `README.md`, perfectly aligning it with what's documented in the `dlock-jdbc` sub-module and the required initial setup to avoid database errors.
- Refactoring `SimpleKeyLock.tryLock` to adopt standard Java conventions by using `.isBlank()` instead of `.trim().isEmpty()`.

Tests pass completely with no regressions.

---
*PR created automatically by Jules for task [18385575067657375025](https://jules.google.com/task/18385575067657375025) started by @pmalirz*