### PR TITLE
docs: fix javadoc tag resolution in markdown documentation

### DIFF
--- a/dlock-api/README.md
+++ b/dlock-api/README.md
@@ -13,7 +13,7 @@ public interface KeyLock {
     /**
      * Attempts to acquire a lock by key.
      *
-     * @param lockKey           the key identifying the lock (must be non-blank and max {@value #MAX_LOCK_KEY_LENGTH} characters)
+     * @param lockKey           the key identifying the lock (must be non-blank and max KeyLock.MAX_LOCK_KEY_LENGTH characters)
      * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @return Optional<LockHandle> - Present if acquired, empty if not.
      * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0
@@ -24,7 +24,7 @@ public interface KeyLock {
      * Tries to acquire a lock and, if successful, executes the given action.
      * The lock is automatically released after the action completes.
      *
-     * @param lockKey           the key identifying the lock (must be non-blank and max {@value #MAX_LOCK_KEY_LENGTH} characters)
+     * @param lockKey           the key identifying the lock (must be non-blank and max KeyLock.MAX_LOCK_KEY_LENGTH characters)
      * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0
      */
@@ -36,7 +36,7 @@ public interface KeyLock {
      * Tries to acquire a lock and, if successful, executes the given function.
      * The lock is automatically released after the function completes.
      *
-     * @param lockKey           the key identifying the lock (must be non-blank and max {@value #MAX_LOCK_KEY_LENGTH} characters)
+     * @param lockKey           the key identifying the lock (must be non-blank and max KeyLock.MAX_LOCK_KEY_LENGTH characters)
      * @param expirationSeconds the lock expiration time in seconds (must be greater than 0)
      * @return Optional<R> - Result of the function if lock acquired, empty if not.
      * @throws IllegalArgumentException if lockKey is invalid or expirationSeconds is <= 0


### PR DESCRIPTION
Replaced `{@value ...}` Javadoc annotations with explicit literal constant references in `dlock-api/README.md` as standard markdown renderers do not expand them. Verified other READMEs do not have the same issue. Tests were executed to ensure no regressions.

---
*PR created automatically by Jules for task [4795074754925500423](https://jules.google.com/task/4795074754925500423) started by @pmalirz*